### PR TITLE
Include reactify transform for browserify users

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "autocomplete",
     "combobox",
     "a11y"
-  ]
+  ],
+  "browserify": {
+    "transform": ["reactify"]
+  }
 }


### PR DESCRIPTION
There's a webpack configuration file for webpack users, but nothing for browserify. I suppose ideally the npm module would have the built lib instead of the raw one so that all build systems are supported, but in the meantime this is a low-effort change.