### PR TITLE
Add the event argument in the ArrowDown Handler.

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -103,7 +103,7 @@ let Autocomplete = React.createClass({
   },
 
   keyDownHandlers: {
-    ArrowDown () {
+    ArrowDown (event) {
       event.preventDefault()
       var { highlightedIndex } = this.state
       var index = (


### PR DESCRIPTION
Hi,

You forgot the attribute event in the ArrowDown handler throw an exception in the demo and not work the arrow key down. (ReferenceError: event is not defined)