### PR TITLE
Update to use react-dom

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -1,4 +1,5 @@
 const React = require('react')
+const ReactDOM = require('react-dom')
 const scrollIntoView = require('dom-scroll-into-view')
 
 let _debugStates = []
@@ -69,8 +70,8 @@ let Autocomplete = React.createClass({
 
   maybeScrollItemIntoView () {
     if (this.state.isOpen === true && this.state.highlightedIndex !== null) {
-      var itemNode = React.findDOMNode(this.refs[`item-${this.state.highlightedIndex}`])
-      var menuNode = React.findDOMNode(this.refs.menu)
+      var itemNode = ReactDOM.findDOMNode(this.refs[`item-${this.state.highlightedIndex}`])
+      var menuNode = ReactDOM.findDOMNode(this.refs.menu)
       scrollIntoView(itemNode, menuNode, { onlyScrollIfNeeded: true })
     }
   },
@@ -141,7 +142,7 @@ let Autocomplete = React.createClass({
         this.setState({
           isOpen: false
         }, () => {
-          React.findDOMNode(this.refs.input).select()
+          ReactDOM.findDOMNode(this.refs.input).select()
         })
       }
       else {
@@ -152,7 +153,7 @@ let Autocomplete = React.createClass({
           highlightedIndex: null
         }, () => {
           //React.findDOMNode(this.refs.input).focus() // TODO: file issue
-          React.findDOMNode(this.refs.input).setSelectionRange(
+          ReactDOM.findDOMNode(this.refs.input).setSelectionRange(
             this.state.value.length,
             this.state.value.length
           )
@@ -201,7 +202,7 @@ let Autocomplete = React.createClass({
       this.state.value.toLowerCase()
     ) === 0)
     if (itemValueDoesMatch) {
-      var node = React.findDOMNode(this.refs.input)
+      var node = ReactDOM.findDOMNode(this.refs.input)
       var setSelection = () => {
         node.value = itemValue
         node.setSelectionRange(this.state.value.length, itemValue.length)
@@ -214,7 +215,7 @@ let Autocomplete = React.createClass({
   },
 
   setMenuPositions () {
-    var node = React.findDOMNode(this.refs.input)
+    var node = ReactDOM.findDOMNode(this.refs.input)
     var rect = node.getBoundingClientRect()
     var computedStyle = getComputedStyle(node)
     var marginBottom = parseInt(computedStyle.marginBottom, 10)
@@ -238,7 +239,7 @@ let Autocomplete = React.createClass({
       highlightedIndex: null
     }, () => {
       this.props.onSelect(this.state.value, item)
-      React.findDOMNode(this.refs.input).focus()
+      ReactDOM.findDOMNode(this.refs.input).focus()
       this.setIgnoreBlur(false)
     })
   },


### PR DESCRIPTION
For those on React 0.14 you get a deprecation warning about `React.findDOMNode` going away. This future proofs that.