### PR TITLE
add missing `event` arg to keyDownHandlers

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -103,7 +103,7 @@ let Autocomplete = React.createClass({
   },
 
   keyDownHandlers: {
-    ArrowDown () {
+    ArrowDown (event) {
       event.preventDefault()
       var { highlightedIndex } = this.state
       var index = (


### PR DESCRIPTION
It looks like this `event` arg was accidentally left out - so this puts it in :smile: 